### PR TITLE
feat: Add max_text_length arg to main function

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,126 @@
+import streamlit as st
+import openai
+import requests
+from streamlit_feedback import streamlit_feedback
+import datetime
+
+faces_dict = {"😀": 100,
+    "🙂": 80,
+    "😐": 60,
+    "🙁": 40,
+    "😞": 20
+    }
+
+thumbs_dict = {"👍": 100, "👎": 20}
+
+# TODO
+# get and set messages_feedback_dict to cache in each invocation
+
+messages_feedback_dict = {}
+feedback = {}
+
+def _submit_feedback(user_response, emoji=None):
+    st.toast(f"Feedback submitted", icon=emoji)
+    return user_response.update({"datetime_added": datetime.datetime.now()})
+
+
+
+def chatbot_thumbs_app(streamlit_feedback, debug=False):
+
+    global feedback
+    global messages_feedback_dicts
+
+
+    st.title("💬 Chatbot")
+
+    # with st.sidebar:
+    #     with requests.get("http://chatcrm.org:8990/auth/get-token/") as token_response:
+    #         if "access_token" in token_response.json():
+    #             openai_api_key = token_response.json()["access_token"]
+    #             openai.api_base = "http://chatcrm.org:8990/relay/v1"
+
+    if "messages" not in st.session_state:
+        st.session_state["messages"] = [
+            {"role": "assistant", "content": "How can I help you?"}
+        ]
+
+    messages = st.session_state.messages
+    feedback_kwargs = {
+        "feedback_type": "thumbs",
+        "optional_text_label": "Please provide extra information",
+        "on_submit": _submit_feedback,
+        "multiline_text": True,
+        "max_text_length": 100
+    }
+
+    for n, msg in enumerate(messages):
+        st.chat_message(msg["role"]).write(msg["content"])
+
+        if msg["role"] == "assistant" and n > 1:
+            feedback_key = f"feedback_{int(n/2)}"
+
+            if feedback_key not in st.session_state:
+                st.session_state[feedback_key] = None
+
+            disable_with_score = (
+                st.session_state[feedback_key].get("score")
+                if st.session_state[feedback_key]
+                else None
+            )
+            feedback = streamlit_feedback(
+                **feedback_kwargs,
+                key=feedback_key,
+                disable_with_score=disable_with_score
+            )
+            print("-====> feedback", feedback)
+            if n not in messages_feedback_dict.keys():
+                messages_feedback_dict[n] = feedback
+
+    if prompt := st.chat_input(key=1):
+        messages.append({"role": "user", "content": prompt})
+        st.chat_message("user").write(prompt)
+
+        if debug:
+            st.session_state["response"] = "dummy response"
+
+        response = {
+        "id": "chatcmpl-84oa1FIbAktayvs7uM1njsZKnznFk",
+        "object": "chat.completion",
+        "created": 1696158433,
+        "model": "gpt-3.5-turbo-0613",
+        "choices": [
+        {
+            "index": 0,
+            "message": {
+            "role": "assistant",
+            "content": "Hello! How can I assist you today?"
+            },
+            "finish_reason": "stop"
+        }
+        ],
+        "usage": {
+        "prompt_tokens": 18,
+        "completion_tokens": 9,
+        "total_tokens": 27
+        }
+        }
+
+        print(response["choices"][0]["message"]["content"])
+        st.session_state["response"] = response["choices"][0]["message"]["content"]
+        with st.chat_message("assistant"):
+            messages.append(
+                {"role": "assistant", "content": st.session_state["response"]}
+            )
+            st.write(st.session_state["response"])
+
+        streamlit_feedback(**feedback_kwargs, key=f"feedback_{int(len(messages)/2)}")
+
+    if feedback:
+        print("==> received feedback", messages_feedback_dict)
+        # messages_feedback_dict[len(messages) - 1] = feedback
+
+
+
+
+
+chatbot_thumbs_app(streamlit_feedback=streamlit_feedback, debug=False)

--- a/streamlit_feedback/__init__.py
+++ b/streamlit_feedback/__init__.py
@@ -25,6 +25,7 @@ else:
 def streamlit_feedback(
     feedback_type,
     optional_text_label=None,
+    max_text_length=None,
     disable_with_score=None,
     on_submit=None,
     args=(),
@@ -41,6 +42,8 @@ def streamlit_feedback(
     optional_text_label: str or None
         An optional label to add as a placeholder to the textbox.
         If None, the "thumbs" or "faces" will not be accompanied by textual feedback.
+    max_text_length: int or None
+        Optional. Determines the maximum characters the textbox allows. Use it to enable the textbox to display the text in multiple lines.
     disable_with_score: str
         An optional score to disable the component. Must be a "thumbs" emoji or a "faces" emoji. Can be used to pass state from one component to another.
     on_submit: callable
@@ -97,6 +100,7 @@ def streamlit_feedback(
     component_value = _component_func(
         feedback_type=feedback_type,
         optional_text_label=optional_text_label,
+        max_text_length=max_text_length,
         disable_with_score=disable_with_score,
         align=align,
         key=key,
@@ -121,13 +125,24 @@ def streamlit_feedback(
 
 
 if not _RELEASE:
-    from examples import (
-        bare_bones_app,
-        basic_app,
-        chatbot_thumbs_app,
-        single_prediction_faces_app,
-        streaming_chatbot,
-    )
+
+    # Added a try-except to make setting up the development environment for this project easier.
+    try:
+        from examples import (
+            bare_bones_app,
+            basic_app,
+            chatbot_thumbs_app,
+            single_prediction_faces_app,
+            streaming_chatbot,
+        )
+    except:
+        from .examples import (
+            bare_bones_app,
+            basic_app,
+            chatbot_thumbs_app,
+            single_prediction_faces_app,
+            streaming_chatbot,
+        )
 
     page_names_to_funcs = {
         "Chatbot": chatbot_thumbs_app,

--- a/streamlit_feedback/__init__.py
+++ b/streamlit_feedback/__init__.py
@@ -25,7 +25,8 @@ else:
 def streamlit_feedback(
     feedback_type,
     optional_text_label=None,
-    max_text_length=None,
+    multiline_text=False,
+    max_text_length=300,
     disable_with_score=None,
     on_submit=None,
     args=(),
@@ -42,8 +43,10 @@ def streamlit_feedback(
     optional_text_label: str or None
         An optional label to add as a placeholder to the textbox.
         If None, the "thumbs" or "faces" will not be accompanied by textual feedback.
-    max_text_length: int or None
-        Optional. Determines the maximum characters the textbox allows. Use it to enable the textbox to display the text in multiple lines.
+    multiline_text: boolean
+        Defaults to False. Enables multi-line text. Used in conjunction with max_text_length.
+    max_text_length: int
+        Defaults to 300. Must be used with multiline_text. Determines the maximum characters the textbox allows when used with multiline_text.
     disable_with_score: str
         An optional score to disable the component. Must be a "thumbs" emoji or a "faces" emoji. Can be used to pass state from one component to another.
     on_submit: callable
@@ -100,6 +103,7 @@ def streamlit_feedback(
     component_value = _component_func(
         feedback_type=feedback_type,
         optional_text_label=optional_text_label,
+        multiline_text=multiline_text,
         max_text_length=max_text_length,
         disable_with_score=disable_with_score,
         align=align,

--- a/streamlit_feedback/frontend/src/FacesWithQualiFeedback.js
+++ b/streamlit_feedback/frontend/src/FacesWithQualiFeedback.js
@@ -95,7 +95,7 @@ export function FacesWithQualiFeedback(props) {
     };
 
     return (
-        <Box paddingY={0.5}>
+        <Box paddingY={0.5} height={props.maxTextLength * 2.5}>
             <Stack direction="row" spacing={1} justifyContent={props.align}>
                 <SentimentVeryDissatisfiedIcon
                 sx={{
@@ -147,7 +147,7 @@ export function FacesWithQualiFeedback(props) {
                     }, }}
                 onClick={() => submitted ? {} : handleFaceClick("😀")}
                 />
-                {submitted === false && faceScore !== null ? <StyledCustomInput onChange={handleTextInput} aria-label="Demo input" placeholder={props.optionalTextLabel} color={colors[faceScore]}/> : null}
+                {submitted === false && faceScore !== null ? <StyledCustomInput multiline={true} inputProps={{ maxLength: props.maxTextLength,  minRows:2 ,maxrows: props.maxTextLength / 5 }} onChange={handleTextInput} aria-label="Demo input" placeholder={props.optionalTextLabel} color={colors[faceScore]}/> : null}
                 {submitted === false && faceScore !== null ? <Button sx={{color: colors[faceScore]}} variant="text" size="small" onClick={handleSubmission}>Submit</Button> : null}
             </Stack>
         </Box>

--- a/streamlit_feedback/frontend/src/FacesWithQualiFeedbackMultiline.js
+++ b/streamlit_feedback/frontend/src/FacesWithQualiFeedbackMultiline.js
@@ -4,11 +4,11 @@ import SentimentDissatisfiedIcon from '@mui/icons-material/SentimentDissatisfied
 import SentimentNeutralIcon from '@mui/icons-material/SentimentNeutral';
 import SentimentSatisfiedIcon from '@mui/icons-material/SentimentSatisfied';
 import SentimentSatisfiedAltIcon from '@mui/icons-material/SentimentSatisfiedAlt';
-import InputBase from '@mui/material/InputBase';
-import { styled } from '@mui/system';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 import { Box } from "@mui/material";
+import { styled } from '@mui/material/styles';
+import TextField from "@mui/material/TextField";
 
 const colors = {
     grey: "#c7d1d3",
@@ -19,21 +19,31 @@ const colors = {
     "😞": "#f44336"
 }
 
-const StyledCustomInput = styled(InputBase)(
-({ color }) => `
-    width: 60vw;
-    font-family: sans-serif;
-    font-size: 0.875rem;
-    font-weight: 400;
-    padding: 0px 12px;
-    border-radius: 8px;
-    color: ${color};
-    border: 1px solid ${color};
-    background: transparent;
-    `
-);
+const TextFieldcolors = {
+    "😀": "success",
+    "🙂": "success",
+    "😐": "warning",
+    "🙁": "error",
+    "😞": "error"
+}
 
-export function FacesWithQualiFeedback(props) {
+
+const StyledTextField = styled(TextField)(
+    ({ color }) => `
+        width: 60vw;
+        font-family: sans-serif;
+        font-size: 0.875rem;
+        font-weight: 400;
+        padding: 0px 12px;
+        border-radius: 8px;
+        color: ${color};
+        border: 1px solid ${color};
+        background: transparent;
+        `
+    );
+
+
+export function FacesWithQualiFeedbackMultiline(props) {
     const [submitted, setSubmitted] = useState(false);
     const [inputText, setInputText] = useState(null);
     const [faceScore, setFaceScore] = useState(null);
@@ -95,7 +105,7 @@ export function FacesWithQualiFeedback(props) {
     };
 
     return (
-        <Box paddingY={0.5}>
+        <Box paddingY={0.5} height={140} component="form" sx={{"& .MuiTextField-root": { m: 1, width: "50ch" } }} noValidate autoComplete="off">
             <Stack direction="row" spacing={1} justifyContent={props.align}>
                 <SentimentVeryDissatisfiedIcon
                 sx={{
@@ -147,7 +157,7 @@ export function FacesWithQualiFeedback(props) {
                     }, }}
                 onClick={() => submitted ? {} : handleFaceClick("😀")}
                 />
-                {submitted === false && faceScore !== null ? <StyledCustomInput onChange={handleTextInput} aria-label="Demo input" placeholder={props.optionalTextLabel} color={colors[faceScore]}/> : null}
+                {submitted === false && faceScore !== null ? <StyledTextField id="outlined-multiline-static" inputProps={{ maxLength: props.maxTextLength }} onChange={handleTextInput} multiline rows={4} placeholder={props.optionalTextLabel} aria-label="Demo input" color={TextFieldcolors[faceScore]}/> : null}
                 {submitted === false && faceScore !== null ? <Button sx={{color: colors[faceScore]}} variant="text" size="small" onClick={handleSubmission}>Submit</Button> : null}
             </Stack>
         </Box>

--- a/streamlit_feedback/frontend/src/MyComponent.js
+++ b/streamlit_feedback/frontend/src/MyComponent.js
@@ -14,6 +14,7 @@ class MyComponent extends StreamlitComponentBase {
         <Feedback
           feedbackType={this.props.args["feedback_type"]}
           optionalTextLabel={this.props.args["optional_text_label"]}
+          maxTextLength={this.props.args["max_text_length"]}
           disableWithScore={this.props.args["disable_with_score"]}
           align={this.props.args["align"]}
           default={this.props.args["default"]}

--- a/streamlit_feedback/frontend/src/MyComponent.js
+++ b/streamlit_feedback/frontend/src/MyComponent.js
@@ -14,6 +14,7 @@ class MyComponent extends StreamlitComponentBase {
         <Feedback
           feedbackType={this.props.args["feedback_type"]}
           optionalTextLabel={this.props.args["optional_text_label"]}
+          multiLineText={this.props.args["multiline_text"]}
           maxTextLength={this.props.args["max_text_length"]}
           disableWithScore={this.props.args["disable_with_score"]}
           align={this.props.args["align"]}

--- a/streamlit_feedback/frontend/src/ThumbsWithQualiFeedback.js
+++ b/streamlit_feedback/frontend/src/ThumbsWithQualiFeedback.js
@@ -86,7 +86,7 @@ export function ThumbsWithQualiFeedback(props) {
     };
 
     return (
-        <Box paddingY={0.5}>
+        <Box paddingY={0.5} height={props.maxTextLength * 2.5}>
             <Stack direction="row" spacing={1} justifyContent={props.align}>
                 <ThumbUpOffAltIcon
                 sx={{
@@ -108,7 +108,7 @@ export function ThumbsWithQualiFeedback(props) {
                 }, }}
                 onClick={() => submitted ? {} : handleThumbClick("👎")}
                 />
-                {submitted === false && thumbScore !== null ? <StyledCustomInput onChange={handleTextInput} aria-label="Demo input" placeholder={props.optionalTextLabel} color={thumbScore === "👍" ? colors["colorUp"] : colors["colorDown"]}/> : null}
+                {submitted === false && thumbScore !== null ? <StyledCustomInput multiline={true} inputProps={{ maxLength: props.maxTextLength,  minRows:2, maxrows: props.maxTextLength / 5 }} onChange={handleTextInput} aria-label="Demo input" placeholder={props.optionalTextLabel} color={thumbScore === "👍" ? colors["colorUp"] : colors["colorDown"]}/> : null}
                 {submitted === false && thumbScore !== null ? <Button sx={{color: thumbScore === "👍" ? colors["colorUp"] : colors["colorDown"]}} variant="text" size="small" onClick={handleSubmission}>Submit</Button> : null}
             </Stack>
         </Box>

--- a/streamlit_feedback/frontend/src/ThumbsWithQualiFeedbackMultiline.js
+++ b/streamlit_feedback/frontend/src/ThumbsWithQualiFeedbackMultiline.js
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from "react";
 import ThumbDownOffAltIcon from '@mui/icons-material/ThumbDownOffAlt';
 import ThumbUpOffAltIcon from '@mui/icons-material/ThumbUpOffAlt';
-import InputBase from '@mui/material/InputBase';
-import { styled } from '@mui/system';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 import { Box } from "@mui/material";
+import { styled } from '@mui/material/styles';
+import TextField from "@mui/material/TextField";
 
 const colors = {
     colorGrey: "#c7d1d3",
@@ -13,21 +13,26 @@ const colors = {
     colorDown: "#f44336"
 }
 
-const StyledCustomInput = styled(InputBase)(
-({ color }) => `
-    width: 70vw;
-    font-family: sans-serif;
-    font-size: 0.875rem;
-    font-weight: 400;
-    padding: 0px 12px;
-    border-radius: 8px;
-    color: ${color};
-    border: 1px solid ${color};
-    background: transparent;
-    `
-);
+const TextFieldcolors = {
+    colorUp: "success",
+    colorDown: "error"
+}
 
-export function ThumbsWithQualiFeedback(props) {
+const StyledTextField = styled(TextField)(
+    ({ color }) => `
+        width: 60vw;
+        font-family: sans-serif;
+        font-size: 0.875rem;
+        font-weight: 400;
+        padding: 0px 12px;
+        border-radius: 8px;
+        color: ${color};
+        border: 1px solid ${color};
+        background: transparent;
+        `
+    );
+
+export function ThumbsWithQualiFeedbackMultiline(props) {
     const [thumbScore, setThumbScore] = useState(null);
     const [submitted, setSubmitted] = useState(false);
     const [inputText, setInputText] = useState(null);
@@ -86,7 +91,7 @@ export function ThumbsWithQualiFeedback(props) {
     };
 
     return (
-        <Box paddingY={0.5}>
+        <Box paddingY={0.5} height={140} component="form" sx={{"& .MuiTextField-root": { m: 1, width: "50ch" } }} noValidate autoComplete="off">
             <Stack direction="row" spacing={1} justifyContent={props.align}>
                 <ThumbUpOffAltIcon
                 sx={{
@@ -108,7 +113,7 @@ export function ThumbsWithQualiFeedback(props) {
                 }, }}
                 onClick={() => submitted ? {} : handleThumbClick("👎")}
                 />
-                {submitted === false && thumbScore !== null ? <StyledCustomInput onChange={handleTextInput} aria-label="Demo input" placeholder={props.optionalTextLabel} color={thumbScore === "👍" ? colors["colorUp"] : colors["colorDown"]}/> : null}
+                {submitted === false && thumbScore !== null ? <StyledTextField id="outlined-multiline-static" inputProps={{ maxLength: props.maxTextLength }} onChange={handleTextInput} multiline rows={4} placeholder={props.optionalTextLabel} aria-label="Demo input" color={thumbScore === "👍" ? TextFieldcolors["colorUp"] : TextFieldcolors["colorDown"]}/> : null}
                 {submitted === false && thumbScore !== null ? <Button sx={{color: thumbScore === "👍" ? colors["colorUp"] : colors["colorDown"]}} variant="text" size="small" onClick={handleSubmission}>Submit</Button> : null}
             </Stack>
         </Box>

--- a/streamlit_feedback/frontend/src/feedback.js
+++ b/streamlit_feedback/frontend/src/feedback.js
@@ -1,8 +1,10 @@
 import React from "react";
 import { ThumbsFeedback } from "./ThumbsFeedback";
 import { ThumbsWithQualiFeedback } from "./ThumbsWithQualiFeedback";
+import { ThumbsWithQualiFeedbackMultiline } from "./ThumbsWithQualiFeedbackMultiline";
 import { FacesFeedback } from "./FacesFeedback";
 import { FacesWithQualiFeedback } from "./FacesWithQualiFeedback";
+import { FacesWithQualiFeedbackMultiline } from "./FacesWithQualiFeedbackMultiline";
 import { Streamlit } from "streamlit-component-lib"
 
 export function Feedback(props) {
@@ -12,12 +14,16 @@ export function Feedback(props) {
 
     if (props.feedbackType === "thumbs" && props.optionalTextLabel === null) {
         return (<ThumbsFeedback submitFeedback={submitFeedback} disableWithScore={props.disableWithScore} align={props.align}/>)
-    } else if (props.feedbackType === "thumbs" && props.optionalTextLabel !== null) {
-        return (<ThumbsWithQualiFeedback submitFeedback={submitFeedback} optionalTextLabel={props.optionalTextLabel} maxTextLength={props.maxTextLength}  disableWithScore={props.disableWithScore} align={props.align}/>)
+    } else if (props.feedbackType === "thumbs" && props.optionalTextLabel !== null && props.multiLineText === false) {
+        return (<ThumbsWithQualiFeedback submitFeedback={submitFeedback} optionalTextLabel={props.optionalTextLabel} disableWithScore={props.disableWithScore} align={props.align}/>)
+    } else if (props.feedbackType === "thumbs" && props.optionalTextLabel !== null && props.multiLineText === true) {
+        return (<ThumbsWithQualiFeedbackMultiline submitFeedback={submitFeedback} optionalTextLabel={props.optionalTextLabel} maxTextLength={props.maxTextLength}  disableWithScore={props.disableWithScore} align={props.align}/>)
     } else if (props.feedbackType === "faces" && props.optionalTextLabel === null) {
         return (<FacesFeedback submitFeedback={submitFeedback} disableWithScore={props.disableWithScore} align={props.align}/>)
-    } else if (props.feedbackType === "faces" && props.optionalTextLabel !== null) {
-        return (<FacesWithQualiFeedback submitFeedback={submitFeedback} optionalTextLabel={props.optionalTextLabel} maxTextLength={props.maxTextLength}  disableWithScore={props.disableWithScore} align={props.align}/>)
+    } else if (props.feedbackType === "faces" && props.optionalTextLabel !== null && props.multiLineText === false) {
+        return (<FacesWithQualiFeedback submitFeedback={submitFeedback} optionalTextLabel={props.optionalTextLabel} disableWithScore={props.disableWithScore} align={props.align}/>)
+    } else if (props.feedbackType === "faces" && props.optionalTextLabel !== null && props.multiLineText === true) {
+        return (<FacesWithQualiFeedbackMultiline submitFeedback={submitFeedback} optionalTextLabel={props.optionalTextLabel} maxTextLength={props.maxTextLength}  disableWithScore={props.disableWithScore} align={props.align}/>)
     } else if (props.feedbackType === "textbox") {
         return (<div />)
     }

--- a/streamlit_feedback/frontend/src/feedback.js
+++ b/streamlit_feedback/frontend/src/feedback.js
@@ -13,11 +13,11 @@ export function Feedback(props) {
     if (props.feedbackType === "thumbs" && props.optionalTextLabel === null) {
         return (<ThumbsFeedback submitFeedback={submitFeedback} disableWithScore={props.disableWithScore} align={props.align}/>)
     } else if (props.feedbackType === "thumbs" && props.optionalTextLabel !== null) {
-        return (<ThumbsWithQualiFeedback submitFeedback={submitFeedback} optionalTextLabel={props.optionalTextLabel} disableWithScore={props.disableWithScore} align={props.align}/>)
+        return (<ThumbsWithQualiFeedback submitFeedback={submitFeedback} optionalTextLabel={props.optionalTextLabel} maxTextLength={props.maxTextLength}  disableWithScore={props.disableWithScore} align={props.align}/>)
     } else if (props.feedbackType === "faces" && props.optionalTextLabel === null) {
         return (<FacesFeedback submitFeedback={submitFeedback} disableWithScore={props.disableWithScore} align={props.align}/>)
     } else if (props.feedbackType === "faces" && props.optionalTextLabel !== null) {
-        return (<FacesWithQualiFeedback submitFeedback={submitFeedback} optionalTextLabel={props.optionalTextLabel} disableWithScore={props.disableWithScore} align={props.align}/>)
+        return (<FacesWithQualiFeedback submitFeedback={submitFeedback} optionalTextLabel={props.optionalTextLabel} maxTextLength={props.maxTextLength}  disableWithScore={props.disableWithScore} align={props.align}/>)
     } else if (props.feedbackType === "textbox") {
         return (<div />)
     }


### PR DESCRIPTION
Hi, 
Hope you're doing well.

There was this requirement pertaining to having multi-line feedback texts in Streamlit-feedback. So I went ahead and made it possible as best as I could.

Hope it adds some value to this already awesome package!

----------------------
In the second commit, I have replaced the InputField with a TextField to enable the textbox to be scrollable. Also, I have made sure to preserve the previous one-line textbox and ensure that this feature adds value to the current structure, not modify it.
