### PR TITLE
Add license to PyPI classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,15 @@ setuptools.setup(
     url="",
     packages=setuptools.find_packages(),
     include_package_data=True,
-    classifiers=[],
+    classifiers=[
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+    ],
     python_requires=">=3.7",
     install_requires=[
         # By definition, a Custom Component depends on Streamlit.


### PR DESCRIPTION
Adds [PyPI project classifiers](https://pypi.org/classifiers/)
Classifiers are used to add information to the classifiers panel in PyPI. Example from [NumPy](https://pypi.org/project/numpy/):
![image](https://github.com/trubrics/streamlit-feedback/assets/7910938/2d069fde-9665-475a-8065-b40141347a58)


The reason that it is very important for this information to be present is that in an enterprise environment, security tools like [Sonatype Nexus IQ](https://help.sonatype.com/iqserver) are used to manage open source software risk. Nexus IQ specifically can be configured to [classify packages according to their license](https://help.sonatype.com/iqserver/managing/policy-management/license-threat-groups). This prevents developers from inadvertently using licenses like [GNU General Public License v2.0](https://www.tldrlegal.com/license/gnu-general-public-license-v2) without realizing that they may be legally obligated to make their entire project open source.

My understanding is that Nexus IQ uses the classifiers panel to determine a project's license.
Because streamlit-feedback does not currently have a classifiers panel, Nexus cannot determine the license and treats it as a high-risk package.
![image](https://github.com/trubrics/streamlit-feedback/assets/7910938/6134cabe-0bd9-4f07-b51a-7c2a3b975aaf)


By adding classifiers, streamlit-feedback will have increased availability within enterprise environments.

I added a few other classifiers which seemed reasonable and appropriate. This is a great opportunity to add more if desired.