### PR TITLE
Option to ask for textual feedback only in case of negative review.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ def streamlit_feedback(
     feedback_type,
     optional_text_label=None,
     max_text_length=None,
+    review_on_positive=True,
     disable_with_score=None,
     on_submit=None,
     args=(),
@@ -52,6 +53,8 @@ def streamlit_feedback(
         Defaults to None. If set, enables the multi-line functionality and determines the maximum characters the textbox allows. Else, displays the default one-line textbox.
     disable_with_score: str
         An optional score to disable the component. Must be a "thumbs" emoji or a "faces" emoji. Can be used to pass state from one component to another.
+    review_on_positive: bool
+        Defaults to True. When set to False, it only asks for textual feedback in case of a negative review, i.e., "thumbs down" or less than the happiest "faces" emoji.
     on_submit: callable
         An optional callback invoked when feedback is submitted. This function must accept at least one argument, the feedback response dict,
         allowing you to save the feedback to a database for example. Additional arguments can be specified using `args` and `kwargs`.

--- a/streamlit_feedback/__init__.py
+++ b/streamlit_feedback/__init__.py
@@ -27,6 +27,7 @@ def streamlit_feedback(
     optional_text_label=None,
     max_text_length=None,
     disable_with_score=None,
+    review_on_positive=True,
     on_submit=None,
     args=(),
     kwargs={},
@@ -46,6 +47,8 @@ def streamlit_feedback(
         Defaults to None. If set, enables the multi-line functionality and determines the maximum characters the textbox allows. Else, displays the default one-line textbox.
     disable_with_score: str
         An optional score to disable the component. Must be a "thumbs" emoji or a "faces" emoji. Can be used to pass state from one component to another.
+    review_on_positive: bool
+        Defaults to True. When set to False, it only asks for textual feedback in case of a negative review, i.e., "thumbs down" or less than the happiest "faces" emoji.
     on_submit: callable
         An optional callback invoked when feedback is submitted. This function must accept at least one argument, the feedback response dict,
         allowing you to save the feedback to a database for example. Additional arguments can be specified using `args` and `kwargs`.
@@ -105,6 +108,7 @@ def streamlit_feedback(
         feedback_type=feedback_type,
         optional_text_label=optional_text_label,
         max_text_length=max_text_length,
+        review_on_positive=review_on_positive,
         disable_with_score=disable_with_score,
         align=align,
         key=key,
@@ -140,7 +144,7 @@ if not _RELEASE:
             streaming_chatbot,
         )
     except:
-        from .examples import (
+        from examples import (
             bare_bones_app,
             basic_app,
             chatbot_thumbs_app,

--- a/streamlit_feedback/examples.py
+++ b/streamlit_feedback/examples.py
@@ -37,6 +37,7 @@ def chatbot_thumbs_app(streamlit_feedback, debug=False):
             streamlit_feedback(
                 feedback_type="thumbs",
                 optional_text_label="Please provide extra information",
+                review_on_positive=False,
                 on_submit=_submit_feedback,
                 key=feedback_key,
             )
@@ -112,6 +113,7 @@ def single_prediction_faces_app(streamlit_feedback, debug=False):
         streamlit_feedback(
             feedback_type="faces",
             optional_text_label="Please provide extra information",
+            review_on_positive=False,
             align="flex-start",
             on_submit=_submit_feedback,
             key=f"feedback_{st.session_state.feedback_key}",

--- a/streamlit_feedback/frontend/src/FacesWithQualiFeedback.js
+++ b/streamlit_feedback/frontend/src/FacesWithQualiFeedback.js
@@ -179,6 +179,8 @@ export function FacesWithQualiFeedback(props) {
                         onClick={() => submitted ? {} : handleFaceClick("😀")}
                     />
                     {submitted === false && faceScore !== null ? <StyledTextField id="outlined-multiline-static" inputProps={{ maxLength: props.maxTextLength }} onChange={handleTextInput} multiline rows={4} placeholder={props.optionalTextLabel} aria-label="Demo input" color={TextFieldcolors[faceScore]} /> : null}
+                    {submitted === false && faceScore !== null && props.reviewOnPositive === true ? <StyledTextField id="outlined-multiline-static" inputProps={{ maxLength: props.maxTextLength }} onChange={handleTextInput} multiline rows={4} placeholder={props.optionalTextLabel} aria-label="Demo input" color={TextFieldcolors[faceScore]} /> : null}
+                    {submitted === false && faceScore !== "😀" && !props.reviewOnPositive ? <StyledTextField id="outlined-multiline-static" inputProps={{ maxLength: props.maxTextLength }} onChange={handleTextInput} multiline rows={4} placeholder={props.optionalTextLabel} aria-label="Demo input" color={TextFieldcolors[faceScore]} /> : null}
                     {submitted === false && faceScore !== null ? <Button sx={{ color: colors[faceScore] }} variant="text" size="small" onClick={handleSubmission}>Submit</Button> : null}
                 </Stack>
             </Box>
@@ -244,7 +246,9 @@ export function FacesWithQualiFeedback(props) {
                         }}
                         onClick={() => submitted ? {} : handleFaceClick("😀")}
                     />
-                    {submitted === false && faceScore !== null ? <StyledCustomInput onChange={handleTextInput} aria-label="Demo input" placeholder={props.optionalTextLabel} color={colors[faceScore]} /> : null}
+                    {submitted === false && faceScore !== null && props.reviewOnPositive === true ? <StyledCustomInput onChange={handleTextInput} aria-label="Demo input" placeholder={props.optionalTextLabel} color={colors[faceScore]} /> : null}
+                    {submitted === false && faceScore !== "😀" && !props.reviewOnPositive? <StyledCustomInput onChange={handleTextInput} aria-label="Demo input" placeholder={props.optionalTextLabel} color={colors[faceScore]} /> : null}
+                    {/* {submitted === false && faceScore !== null ? <StyledCustomInput onChange={handleTextInput} aria-label="Demo input" placeholder={props.optionalTextLabel} color={colors[faceScore]} /> : null} */}
                     {submitted === false && faceScore !== null ? <Button sx={{ color: colors[faceScore] }} variant="text" size="small" onClick={handleSubmission}>Submit</Button> : null}
                 </Stack>
             </Box>

--- a/streamlit_feedback/frontend/src/MyComponent.js
+++ b/streamlit_feedback/frontend/src/MyComponent.js
@@ -14,6 +14,7 @@ class MyComponent extends StreamlitComponentBase {
         <Feedback
           feedbackType={this.props.args["feedback_type"]}
           optionalTextLabel={this.props.args["optional_text_label"]}
+          reviewOnPositive={this.props.args["review_on_positive"]}
           maxTextLength={this.props.args["max_text_length"]}
           disableWithScore={this.props.args["disable_with_score"]}
           align={this.props.args["align"]}

--- a/streamlit_feedback/frontend/src/ThumbsWithQualiFeedback.js
+++ b/streamlit_feedback/frontend/src/ThumbsWithQualiFeedback.js
@@ -132,6 +132,8 @@ export function ThumbsWithQualiFeedback(props) {
                         }}
                         onClick={() => submitted ? {} : handleThumbClick("👎")}
                     />
+                    {submitted === false && thumbScore !== null && props.reviewOnPositive === true? <StyledTextField id="outlined-multiline-static-all" inputProps={{ maxLength: props.maxTextLength }} onChange={handleTextInput} multiline rows={4} placeholder={props.optionalTextLabel} aria-label="Demo input" color={thumbScore === "👍" ? TextFieldcolors["colorUp"] : TextFieldcolors["colorDown"]} /> : null}
+                    {submitted === false && thumbScore === "👎" && !props.reviewOnPositive ? <StyledTextField id="outlined-multiline-static-neg" inputProps={{ maxLength: props.maxTextLength }} onChange={handleTextInput} multiline rows={4} placeholder={props.optionalTextLabel} aria-label="Demo input" color={thumbScore === "👍" ? TextFieldcolors["colorUp"] : TextFieldcolors["colorDown"]} /> : null}
                     {submitted === false && thumbScore !== null ? <StyledTextField id="outlined-multiline-static" inputProps={{ maxLength: props.maxTextLength }} onChange={handleTextInput} multiline rows={4} placeholder={props.optionalTextLabel} aria-label="Demo input" color={thumbScore === "👍" ? TextFieldcolors["colorUp"] : TextFieldcolors["colorDown"]} /> : null}
                     {submitted === false && thumbScore !== null ? <Button sx={{ color: thumbScore === "👍" ? colors["colorUp"] : colors["colorDown"] }} variant="text" size="small" onClick={handleSubmission}>Submit</Button> : null}
                 </Stack>
@@ -164,7 +166,9 @@ export function ThumbsWithQualiFeedback(props) {
                         }}
                         onClick={() => submitted ? {} : handleThumbClick("👎")}
                     />
-                    {submitted === false && thumbScore !== null ? <StyledCustomInput onChange={handleTextInput} aria-label="Demo input" placeholder={props.optionalTextLabel} color={thumbScore === "👍" ? colors["colorUp"] : colors["colorDown"]} /> : null}
+                    {submitted === false && thumbScore !== null && props.reviewOnPositive === true ? <StyledCustomInput onChange={handleTextInput} aria-label="Demo input" placeholder={props.optionalTextLabel} color={thumbScore === "👍" ? colors["colorUp"] : colors["colorDown"]} /> : null}
+                    {submitted === false && thumbScore === "👎" && !props.reviewOnPositive ? <StyledCustomInput onChange={handleTextInput} aria-label="Demo input" placeholder={props.optionalTextLabel} color={thumbScore === "👍" ? colors["colorUp"] : colors["colorDown"]} /> : null}
+                    {/* {submitted === false && thumbScore !== null ? <StyledCustomInput onChange={handleTextInput} aria-label="Demo input" placeholder={props.optionalTextLabel} color={thumbScore === "👍" ? colors["colorUp"] : colors["colorDown"]} /> : null} */}
                     {submitted === false && thumbScore !== null ? <Button sx={{ color: thumbScore === "👍" ? colors["colorUp"] : colors["colorDown"] }} variant="text" size="small" onClick={handleSubmission}>Submit</Button> : null}
                 </Stack>
             </Box>

--- a/streamlit_feedback/frontend/src/feedback.js
+++ b/streamlit_feedback/frontend/src/feedback.js
@@ -13,15 +13,15 @@ export function Feedback(props) {
     if (props.feedbackType === "thumbs" && props.optionalTextLabel === null) {
         return (<ThumbsFeedback submitFeedback={submitFeedback} disableWithScore={props.disableWithScore} align={props.align}/>)
     } else if (props.feedbackType === "thumbs" && props.optionalTextLabel !== null && props.maxTextLength === null) {
-        return (<ThumbsWithQualiFeedback submitFeedback={submitFeedback} optionalTextLabel={props.optionalTextLabel} disableWithScore={props.disableWithScore} align={props.align}/>)
+        return (<ThumbsWithQualiFeedback submitFeedback={submitFeedback} reviewOnPositive={props.reviewOnPositive} optionalTextLabel={props.optionalTextLabel} disableWithScore={props.disableWithScore} align={props.align}/>)
     } else if (props.feedbackType === "thumbs" && props.optionalTextLabel !== null && props.maxTextLength) {
-        return (<ThumbsWithQualiFeedback submitFeedback={submitFeedback} optionalTextLabel={props.optionalTextLabel} maxTextLength={props.maxTextLength}  disableWithScore={props.disableWithScore} align={props.align}/>)
+        return (<ThumbsWithQualiFeedback submitFeedback={submitFeedback} reviewOnPositive={props.reviewOnPositive} optionalTextLabel={props.optionalTextLabel} maxTextLength={props.maxTextLength}  disableWithScore={props.disableWithScore} align={props.align}/>)
     } else if (props.feedbackType === "faces" && props.optionalTextLabel === null && props.maxTextLength === null) {
         return (<FacesFeedback submitFeedback={submitFeedback} disableWithScore={props.disableWithScore} align={props.align}/>)
     } else if (props.feedbackType === "faces" && props.optionalTextLabel !== null && props.maxTextLength === null) {
-        return (<FacesWithQualiFeedback submitFeedback={submitFeedback} optionalTextLabel={props.optionalTextLabel} disableWithScore={props.disableWithScore} align={props.align}/>)
+        return (<FacesWithQualiFeedback submitFeedback={submitFeedback} reviewOnPositive={props.reviewOnPositive} optionalTextLabel={props.optionalTextLabel} disableWithScore={props.disableWithScore} align={props.align}/>)
     } else if (props.feedbackType === "faces" && props.optionalTextLabel !== null && props.maxTextLength) {
-        return (<FacesWithQualiFeedback submitFeedback={submitFeedback} optionalTextLabel={props.optionalTextLabel} maxTextLength={props.maxTextLength}  disableWithScore={props.disableWithScore} align={props.align}/>)
+        return (<FacesWithQualiFeedback submitFeedback={submitFeedback} reviewOnPositive={props.reviewOnPositive} optionalTextLabel={props.optionalTextLabel} maxTextLength={props.maxTextLength}  disableWithScore={props.disableWithScore} align={props.align}/>)
     } else if (props.feedbackType === "textbox") {
         return (<div />)
     }


### PR DESCRIPTION
Solves issue [13](https://github.com/trubrics/streamlit-feedback/issues/13)

- Added an additional Boolean parameter `review_on_positive` that defaults to True. When set to False, it does not ask for textual feedback in case of positive reviews. That includes a thumbs-up emoji and the happiest face emoji.
- Added docstrings and type hints.
- State is being preserved.
- Linter ran successfully.